### PR TITLE
Change dashboard into welcoming page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ $ docker-compose run --rm -p 3000:3000 yarn yarn start
 
 ## eslint
 The linter may be run with `docker-compose run --rm yarn yarn lint` or to automatically fix linting errors with `docker-compose run --rm yarn yarn lint-fix`.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-engine-cockpit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.9.5",

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -18,7 +18,7 @@ const DashboardPage = () => {
                     next and we would also appreciate feedback from you! Therefore, if you feel like something is missing or not working as
                     nicely as you would expect it to, please open an
                     <a href="https://github.com/event-engine/cockpit/issues" target="_blank" rel="noopener noreferrer">issue</a>  or create a
-                    <a href="" target="_blank" rel="noopener noreferrer">pull request</a>.
+                    <a href="https://github.com/event-engine/cockpit/pulls" target="_blank" rel="noopener noreferrer">pull request</a>.
                 </div>
             </Grid>
         </Grid>

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -1,10 +1,27 @@
 import React from 'react';
+import {Typography} from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
 
 const DashboardPage = () => {
     return (
-        <div>
-            Event Engine UI - Dashboard
-        </div>
+
+        <Grid container spacing={10}>
+            <Grid item={true} xs={12}>
+                <Typography variant={'h2'}>
+                    Welcome to Event Engine Cockpit!
+                </Typography>
+            </Grid>
+            <Grid item={true} xs={12}>
+                <div>
+                    This project is still under heavy development and it is very likely that there are quite a few bugs, many features to be
+                    implemented and lots of sharp edges to be smoothed out. We have a lot of ideas about what features we want to implement
+                    next and we would also appreciate feedback from you! Therefore, if you feel like something is missing or not working as
+                    nicely as you would expect it to, please open an
+                    <a href="https://github.com/event-engine/cockpit/issues" target="_blank" rel="noopener noreferrer">issue</a>  or create a
+                    <a href="" target="_blank" rel="noopener noreferrer">pull request</a>.
+                </div>
+            </Grid>
+        </Grid>
     );
 };
 

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -71,7 +71,7 @@ const TopBar = (props: TopBarProps) => {
     return (
         <AppBar position={'fixed'} color={'default'} className={classes.root}>
             <MuiToolbar>
-                <Typography variant={'h1'} className={classes.headerText}>Event Engine UI</Typography>
+                <Typography variant={'h1'} className={classes.headerText}>Event Engine Cockpit</Typography>
                 <div className={classes.flexGrow} />
                 <GenerateMenu className={classes.icon} />
                 <IconButton className={classes.icon} title={'Refresh Schema'} onClick={handleRefresh}>

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />


### PR DESCRIPTION
- Renamed `Event Engine UI` into `Event Engine Cockpit` in the top menu
- Copied the intro from the readme into the dashboard page and linked to Github so that the dashboard is welcoming the user instead of an empty page.