### PR TITLE
Fix missing spaces before links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-engine-cockpit",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.9.5",

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -16,9 +16,9 @@ const DashboardPage = () => {
                     This project is still under heavy development and it is very likely that there are quite a few bugs, many features to be
                     implemented and lots of sharp edges to be smoothed out. We have a lot of ideas about what features we want to implement
                     next and we would also appreciate feedback from you! Therefore, if you feel like something is missing or not working as
-                    nicely as you would expect it to, please open an
-                    <a href="https://github.com/event-engine/cockpit/issues" target="_blank" rel="noopener noreferrer">issue</a>  or create a
-                    <a href="https://github.com/event-engine/cockpit/pulls" target="_blank" rel="noopener noreferrer">pull request</a>.
+                    nicely as you would expect it to, please open
+                    an <a href="https://github.com/event-engine/cockpit/issues" target="_blank" rel="noopener noreferrer">issue</a> or create
+                    a <a href="https://github.com/event-engine/cockpit/pulls" target="_blank" rel="noopener noreferrer">pull request</a>.
                 </div>
             </Grid>
         </Grid>


### PR DESCRIPTION
Spaces before links in dashboard text were lost due to rearranging the text. This small PR fixes the problem. 