### PR TITLE
Refresh aggregate infos after command execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-engine-cockpit",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.9.5",

--- a/src/AggregateDetailsPage.tsx
+++ b/src/AggregateDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {Grid} from '@material-ui/core';
 import AggregateDetailsEventsWidget from './pages/aggregateDetails/components/AggregateDetailsEventsWidget';
 import {RouteComponentProps} from 'react-router';
@@ -15,6 +15,11 @@ const AggregateDetailsPage = (props: AggregateDetailsPageProps) => {
     const aggregateType = (props.match.params as any).aggregateType;
     const aggregateId = (props.match.params as any).aggregateId;
     const version = (props.match.params as any).version || undefined;
+    const [commandsExecuted, setCommandsExecuted] = useState(0);
+
+    const handleCommandExecuted = () => {
+        setCommandsExecuted(commandsExecuted + 1);
+    };
 
     return (
         <Grid container={true} spacing={3}>
@@ -24,15 +29,24 @@ const AggregateDetailsPage = (props: AggregateDetailsPageProps) => {
             <Grid item={true} md={6}>
                 <Grid container={true} spacing={3}>
                     <Grid item={true} md={12}>
-                        <AggregateStateView aggregateType={aggregateType} aggregateId={aggregateId} version={version} />
+                        <AggregateStateView aggregateType={aggregateType}
+                                            aggregateId={aggregateId}
+                                            version={version}
+                                            commandsExecuted={commandsExecuted}
+                        />
                     </Grid>
                     <Grid item={true} md={12}>
-                        <AggregateCommandsWidget aggregateType={aggregateType} />
+                        <AggregateCommandsWidget aggregateType={aggregateType}
+                                                 onCommandExecuted={handleCommandExecuted}
+                        />
                     </Grid>
                 </Grid>
             </Grid>
             <Grid item={true} md={6}>
-                <AggregateDetailsEventsWidget aggregateType={aggregateType} aggregateId={aggregateId} />
+                <AggregateDetailsEventsWidget aggregateType={aggregateType} 
+                                              aggregateId={aggregateId}
+                                              commandsExecuted={commandsExecuted}
+                />
             </Grid>
         </Grid>
     );

--- a/src/pages/aggregateDetails/components/AggregateCommandsWidget.tsx
+++ b/src/pages/aggregateDetails/components/AggregateCommandsWidget.tsx
@@ -9,6 +9,7 @@ import CommandDialog from '../../common/components/CommandDialog';
 
 interface AggregateCommandsWidgetProps {
     aggregateType: string;
+    onCommandExecuted?: () => void;
 }
 
 const AggregateCommandsWidget = (props: AggregateCommandsWidgetProps) => {
@@ -18,6 +19,11 @@ const AggregateCommandsWidget = (props: AggregateCommandsWidgetProps) => {
     if (!commands) {
         return null;
     }
+
+    const handleCommandDialogClosed = () => {
+        setCommandDialogCommand(null);
+        props.onCommandExecuted && props.onCommandExecuted();
+    };
 
     return (
         <Card>
@@ -44,7 +50,7 @@ const AggregateCommandsWidget = (props: AggregateCommandsWidgetProps) => {
             {commandDialogCommand !== null && (
                 <CommandDialog
                     open={commandDialogCommand !== null}
-                    onClose={() => setCommandDialogCommand(null)}
+                    onClose={handleCommandDialogClosed}
                     commandDialogCommand={commandDialogCommand}
                 />
             )}

--- a/src/pages/aggregateDetails/components/AggregateDetailsEventsWidget.tsx
+++ b/src/pages/aggregateDetails/components/AggregateDetailsEventsWidget.tsx
@@ -14,6 +14,7 @@ import {fetchAggregateEvents} from '../../../action/aggregateDataCommands';
 interface AggregateDetailsEventsWidgetProps {
     aggregateType: string;
     aggregateId: string;
+    commandsExecuted: number;
 }
 
 const AggregateDetailsEventsWidget = (props: AggregateDetailsEventsWidgetProps) => {
@@ -28,7 +29,7 @@ const AggregateDetailsEventsWidget = (props: AggregateDetailsEventsWidgetProps) 
             dispatch(fetchAggregateEvents({ rawAggregateType, aggregateId: props.aggregateId }));
         }
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    }, [rawAggregateType, props.aggregateId]);
+    }, [rawAggregateType, props.aggregateId, props.commandsExecuted]);
 
     if (null === events) {
         return null;

--- a/src/pages/aggregateDetails/components/AggregateStateView.tsx
+++ b/src/pages/aggregateDetails/components/AggregateStateView.tsx
@@ -15,6 +15,7 @@ import {makeAggregateDetailsUrl} from '../../../routes';
 interface AggregateStateViewProps {
     aggregateType: string;
     aggregateId: string;
+    commandsExecuted: number;
     version?: number|undefined;
 }
 
@@ -31,7 +32,7 @@ const AggregateStateView = (props: AggregateStateViewProps) => {
             dispatch(fetchAggregateState({ rawAggregateType, aggregateId: props.aggregateId, version: props.version}));
         }
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    }, [rawAggregateType, props.aggregateId, props.version]);
+    }, [rawAggregateType, props.aggregateId, props.version, props.commandsExecuted]);
 
     const subheader = props.version ? `Aggregate state at version ${props.version}` : 'Latest aggregate state';
 

--- a/src/pages/aggregates/components/AggregateListWidget.tsx
+++ b/src/pages/aggregates/components/AggregateListWidget.tsx
@@ -42,9 +42,13 @@ const AggregateListWidget = (props: AggregateListProps) => {
             return;
         }
 
+        if (commandDialogOpen) {
+            return;
+        }
+
         dispatch(fetchAggregateList({ rawAggregateType }));
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    }, [props.aggregateType, rawAggregateType]);
+    }, [props.aggregateType, rawAggregateType, commandDialogOpen]);
 
     const openDialogForCommand = (command: Command) => {
         setCommandDialogCommand(command);


### PR DESCRIPTION
This PR adds a quick fix for auto refreshing aggregate list and aggregate details after command execution. It is not perfect, because it is purely based on command dialog being closed.

A better way would be to refresh after successful command execution. This way we could automatically close the dialog and trigger refresh. In case command execution fails the dialog would stay open and no refresh is triggered. @martin-schilling this would be perfect case for an event dispatcher redux middleware (you remember our discussion about the topic?).

Anyway, I think the quick fix is ok for now. It definitely increases UX because at the moment you have to refresh the browser to see updates.