### PR TITLE
Allow server to provide aggregate relations

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,6 +14,8 @@ export enum MultiStoreMode {
     State = 'mode_s',
 }
 
+export type AggregateRelations = {[prop: string]: string};
+
 export interface Aggregate {
     aggregateType: string;
     aggregateIdentifier: string;
@@ -22,6 +24,7 @@ export interface Aggregate {
     multiStoreMode: MultiStoreMode;
     commands: Command[];
     events: Event[];
+    relations?: AggregateRelations;
 }
 
 export interface Query {

--- a/src/saga/fetchSystemSchemaFlow.ts
+++ b/src/saga/fetchSystemSchemaFlow.ts
@@ -1,14 +1,27 @@
 import { call, fork, put, take } from 'redux-saga/effects';
 import {fetchSystemSchema} from '../action/systemSchemaCommands';
-import {SystemSchema} from '../api/types';
+import {AggregateRelations, SystemSchema} from '../api/types';
 import {systemSchemaFetched} from '../action/systemSchemaEvents';
 import {getSystemSchema} from '../api';
 import {onEnqueueErrorSnackbar} from './enqueueSnackbarFlow';
+import {eeUiConfig, updateEeUiConfigEnv} from '../config';
+import * as _ from 'lodash';
 
 export const onFetchSystemSchema = function*() {
     try {
         const systemSchema: SystemSchema = yield call(getSystemSchema);
         yield put(systemSchemaFetched({ systemSchema }));
+
+        const config = eeUiConfig();
+        const aggregateConfig: {[aggregateType: string]: AggregateRelations} = _.clone(config.env.aggregateConfig);
+        for(const aggregate of systemSchema.aggregates) {
+            const userDefinedRelations = aggregateConfig[aggregate.aggregateType] || {};
+            if(aggregate.relations) {
+                aggregateConfig[aggregate.aggregateType] = {...aggregate.relations, ...userDefinedRelations};
+            }
+        }
+        updateEeUiConfigEnv({aggregateConfig});
+
     } catch (e) {
         yield call(onEnqueueErrorSnackbar, 'Loading the system schema failed');
     }


### PR DESCRIPTION
With the PR the server can provide aggregate relations that are merged with the user defined `aggregateConfig`. This feature is particularly useful for the integration with InspectIO and the code generator. Developers can define relations already in InspectIO and the info is forwarded by the backend to Cockpit.