### PR TITLE
Add EventsPage similar to CommandsPage

### DIFF
--- a/src/EventsPage.tsx
+++ b/src/EventsPage.tsx
@@ -1,0 +1,88 @@
+import React, {useState} from 'react';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    Divider,
+    Grid,
+} from '@material-ui/core';
+import {Event} from './api/types';
+import {useSelector} from 'react-redux';
+import {makeEventListSelector} from './selector/systemSchemaSelector';
+import {Redirect, RouteComponentProps, withRouter} from 'react-router';
+import * as Route from './routes';
+import EventCategoryExpansionPanel from './pages/events/EventCategoryExpansionPanel';
+import EventForm from './pages/events/EventForm';
+
+interface EventsPageParams {
+    event?: string;
+}
+
+interface EventsPageProps extends RouteComponentProps<EventsPageParams> {}
+
+const EventsPage = (props: EventsPageProps) => {
+    const events = useSelector(makeEventListSelector());
+
+    const [selectedEvent, setSelectedEvent] = useState<string|undefined>(props.match.params.event);
+    const [shouldRedirect, setShouldRedirect] = useState(false);
+
+    const categorizedEvents = events.reduce(
+        (accumulator: Record<string, Event[]>, event: Event) => {
+            const category = event.aggregateType || 'Public Events';
+            return { ...accumulator, [category]: [...(accumulator[category] || []), event] };
+        },
+        {}
+    );
+
+    const handleChangeSelectedEvent = (newEvent: string) => {
+        setSelectedEvent(newEvent);
+        setShouldRedirect(true);
+    };
+
+    const selectedEventObject = events.find(event => event.eventName === selectedEvent);
+
+    if(shouldRedirect && props.match.params.event === selectedEvent) {
+        setShouldRedirect(false);
+    }
+
+    return (
+        <>
+            {shouldRedirect && <Redirect to={Route.makeExecuteEventPath(selectedEvent as string)} />}
+            <Grid container={true} spacing={3}>
+                <Grid item={true} md={3}>
+                    <Card>
+                        <CardHeader title={'Events'} />
+                        <Divider />
+                        <CardContent>
+                            {categorizedEvents['Public Events'] && <EventCategoryExpansionPanel
+                                key={'Public Events'}
+                                category={'Public Events'}
+                                eventList={categorizedEvents['Public Events']}
+                                selectedEvent={selectedEvent}
+                                onChangeSelectedEvent={handleChangeSelectedEvent}
+                            />}
+                            {Object.keys(categorizedEvents).map(category => {
+                                if(category === 'Public Events') {
+                                    return <></>;
+                                }
+
+                                return <EventCategoryExpansionPanel
+                                    key={category}
+                                    category={category}
+                                    eventList={categorizedEvents[category]}
+                                    selectedEvent={selectedEvent}
+                                    onChangeSelectedEvent={handleChangeSelectedEvent}
+                                />;
+                            })}
+                        </CardContent>
+                    </Card>
+                </Grid>
+                <Grid item={true} md={9}>
+                    {selectedEventObject && <EventForm event={selectedEventObject} />}
+                </Grid>
+            </Grid>
+        </>
+    );
+};
+
+export default withRouter(EventsPage);

--- a/src/QueriesPage.tsx
+++ b/src/QueriesPage.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {SyntheticEvent, useState} from 'react';
 import {
     Card,
     CardContent,
@@ -25,6 +25,13 @@ interface QueriesPageParams {
 interface QueriesPageProps extends RouteComponentProps<QueriesPageParams> {}
 
 const useStyles = makeStyles(() => ({
+    queryText: {
+        wordWrap: 'break-word',
+    },
+    queryTextWithMapLink: {
+        wordWrap: 'break-word',
+        paddingRight: '50px',
+    },
     selectedQuery: {
         backgroundColor: 'rgba(0, 0, 0, 0.1) !important',
     },
@@ -41,6 +48,12 @@ const QueriesPage = (props: QueriesPageProps) => {
     const handleChangeSelectedQuery = (queryName: string) => {
         setSelectedQuery(queryName);
         setShouldRedirect(true);
+    };
+
+    const handleEventMapClick = (e: SyntheticEvent, query: Query) => {
+        e.preventDefault();
+
+        window.open(query.eventMapLink, 'IIOEventMap');
     };
 
     if(shouldRedirect && props.match.params.query === selectedQuery) {
@@ -64,13 +77,13 @@ const QueriesPage = (props: QueriesPageProps) => {
                                         className={query.queryName === selectedQuery ? classes.selectedQuery : ''}
                                         onClick={() => handleChangeSelectedQuery(query.queryName)}
                                     >
-                                        <ListItemText primary={query.queryName} />
+                                        <ListItemText
+                                            primary={query.queryName}
+                                            className={(query.eventMapLink? classes.queryTextWithMapLink : classes.queryText)} />
                                         {query.eventMapLink && <ListItemSecondaryAction>
-                                            <a href={query.eventMapLink} target="_blank" rel="noopener noreferrer" title="show on event map">
-                                                <IconButton>
-                                                    <MapIcon />
-                                                </IconButton>
-                                            </a>
+                                            <IconButton onClick={e => handleEventMapClick(e, query)} title="show on event map">
+                                                <MapIcon />
+                                            </IconButton>
                                         </ListItemSecondaryAction>}
                                     </ListItem>
                                 ))}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -3,7 +3,7 @@ export interface SystemSchema {
     aggregates: Aggregate[];
     queries: Query[];
     commands: Command[];
-    events: Event[];
+    events?: Event[];
     definitions: Record<string, any>;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -3,6 +3,7 @@ export interface SystemSchema {
     aggregates: Aggregate[];
     queries: Query[];
     commands: Command[];
+    events: Event[];
     definitions: Record<string, any>;
 }
 
@@ -45,6 +46,7 @@ export interface Command {
 export interface Event {
     eventName: string;
     schema: JSONSchema;
+    aggregateType?: string;
     eventMapLink?: string;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import {
     aggregateDetailsPath,
     aggregatePath,
     commandsPath,
-    dashboardPath, executeCommandPath,
+    dashboardPath, eventsPath, executeCommandPath, executeEventPath,
     executeQueryPath,
     queriesPath,
 } from './routes';
@@ -23,6 +23,7 @@ import { persistor, store } from './store';
 import QueriesPage from './QueriesPage';
 import ThemeProvider from './material-ui/ThemeProvider';
 import CommandsPage from './CommandsPage';
+import EventsPage from './EventsPage';
 
 const history = createHashHistory();
 
@@ -33,6 +34,8 @@ const Main = () => (
         <Route path={executeQueryPath} exact={true} component={QueriesPage} />
         <Route path={commandsPath} exact={true} component={CommandsPage} />
         <Route path={executeCommandPath} exact={true} component={CommandsPage} />
+        <Route path={eventsPath} exact={true} component={EventsPage} />
+        <Route path={executeEventPath} exact={true} component={EventsPage} />
         <Route path={aggregatePath} exact={true} component={AggregatesPage} />
         <Route path={aggregateDetailsPath} exact={true} component={AggregateDetailsPage} />
         <Redirect from={'/'} to={dashboardPath} />

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -32,7 +32,7 @@ interface MainLayoutProps {
 const MainLayout = (props: MainLayoutProps) => {
 
     const classes = useStyles();
-    const [sideBarOpen, setSideBarOpen] = useState<boolean>(true);
+    const [sideBarOpen, setSideBarOpen] = useState<boolean>(false);
 
     const pushContent = useMediaQuery(muiTheme.breakpoints.up('lg'), {
         defaultMatches: true,

--- a/src/layout/SideBarContent.tsx
+++ b/src/layout/SideBarContent.tsx
@@ -6,10 +6,11 @@ import {NavLink} from 'react-router-dom';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import LocationSearchingIcon from '@material-ui/icons/LocationSearching';
 import MemoryIcon from '@material-ui/icons/Memory';
-import BuildIcon from '@material-ui/icons/Build';
+import BuildIcon from '@material-ui/icons/BuildOutlined';
+import MailIcon from '@material-ui/icons/MailOutline';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import {commandsPath, dashboardPath, makeAggregateUrl, queriesPath} from '../routes';
+import {commandsPath, dashboardPath, eventsPath, makeAggregateUrl, queriesPath} from '../routes';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -89,6 +90,20 @@ const SideBarContent = () => {
                         <>
                             <div className={classes.icon}><BuildIcon /></div>
                             Commands
+                        </>
+                    )}
+                />
+            </ListItem>
+            <ListItem className={classes.item} disableGutters={true}>
+                <Button
+                    activeClassName={classes.active}
+                    className={classes.button}
+                    component={NavLink}
+                    to={eventsPath}
+                    children={(
+                        <>
+                            <div className={classes.icon}><MailIcon /></div>
+                            Events
                         </>
                     )}
                 />

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -58,7 +58,7 @@ const TopBar = (props: TopBarProps) => {
         return () => {
             window.removeEventListener('focus', handleRefresh);
         };
-    }, []);
+    });
 
     const handleRefresh = () => {
         dispatch(fetchSystemSchema({}));

--- a/src/layout/TopBar.tsx
+++ b/src/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {
     AppBar,
     Hidden,
@@ -51,6 +51,14 @@ const TopBar = (props: TopBarProps) => {
     const dispatch = useDispatch();
     const theme = useSelector(makeThemeSelector());
     const [settingsOpen, setSettingsOpen] = useState<boolean>(false);
+
+    useEffect(() => {
+        window.addEventListener('focus', handleRefresh);
+
+        return () => {
+            window.removeEventListener('focus', handleRefresh);
+        };
+    }, []);
 
     const handleRefresh = () => {
         dispatch(fetchSystemSchema({}));

--- a/src/pages/commands/components/CommandCategoryExpansionPanel.tsx
+++ b/src/pages/commands/components/CommandCategoryExpansionPanel.tsx
@@ -8,10 +8,17 @@ import {
     makeStyles,
 } from '@material-ui/core';
 import {Command} from '../../../api/types';
-import React from 'react';
+import React, {SyntheticEvent} from 'react';
 import MapIcon from '@material-ui/icons/Map';
 
 const useStyles = makeStyles(() => ({
+    commandText: {
+        wordWrap: 'break-word',
+    },
+    commandTextWithMapLink: {
+        wordWrap: 'break-word',
+        paddingRight: '50px',
+    },
     selectedCommand: {
         backgroundColor: 'rgba(0, 0, 0, 0.1) !important',
     },
@@ -32,6 +39,12 @@ const CommandCategoryExpansionPanel = (props: CommandCategoryExpansionPanelProps
 
     const containsSelectedCommand = props.commandList.find(cmd => cmd.commandName === props.selectedCommand);
 
+    const handleEventMapClick = (e: SyntheticEvent, command: Command) => {
+        e.preventDefault();
+
+        window.open(command.eventMapLink, 'IIOEventMap');
+    };
+
     return (
         <ExpansionPanel defaultExpanded={!!containsSelectedCommand}>
             <ExpansionPanelSummary>
@@ -46,13 +59,13 @@ const CommandCategoryExpansionPanel = (props: CommandCategoryExpansionPanelProps
                             className={command.commandName === props.selectedCommand ? classes.selectedCommand : ''}
                             onClick={() => props.onChangeSelectedCommand(command.commandName)}
                         >
-                            <ListItemText primary={command.commandName} />
+                            <ListItemText
+                                primary={command.commandName}
+                                className={(command.eventMapLink? classes.commandTextWithMapLink : classes.commandText)} />
                             {command.eventMapLink && <ListItemSecondaryAction>
-                                <a href={command.eventMapLink} target="_blank" rel="noopener noreferrer" title="show on event map">
-                                    <IconButton>
-                                        <MapIcon />
-                                    </IconButton>
-                                </a>
+                                <IconButton onClick={e => handleEventMapClick(e, command)} title="show on event map">
+                                    <MapIcon />
+                                </IconButton>
                             </ListItemSecondaryAction>}
                         </ListItem>
                     ))}

--- a/src/pages/events/EventCategoryExpansionPanel.tsx
+++ b/src/pages/events/EventCategoryExpansionPanel.tsx
@@ -1,0 +1,78 @@
+import {
+    ExpansionPanel,
+    ExpansionPanelDetails,
+    ExpansionPanelSummary, IconButton,
+    List,
+    ListItem,
+    ListItemSecondaryAction, ListItemText,
+    makeStyles,
+} from '@material-ui/core';
+import {Event} from '../../api/types';
+import React, {SyntheticEvent} from 'react';
+import MapIcon from '@material-ui/icons/Map';
+
+const useStyles = makeStyles(() => ({
+    eventText: {
+        wordWrap: 'break-word',
+    },
+    eventTextWithMapLink: {
+        wordWrap: 'break-word',
+        paddingRight: '50px',
+    },
+    selectedEvent: {
+        backgroundColor: 'rgba(0, 0, 0, 0.1) !important',
+    },
+    list: {
+        width: '100%',
+    },
+}));
+
+interface EventCategoryExpansionPanelProps {
+    category: string;
+    eventList: Event[];
+    selectedEvent: string|undefined;
+    onChangeSelectedEvent: (eventName: string) => void;
+}
+
+const EventCategoryExpansionPanel = (props: EventCategoryExpansionPanelProps) => {
+    const classes = useStyles();
+
+    const containsSelectedEvent = props.eventList.find(evt => evt.eventName === props.selectedEvent);
+
+    const handleEventMapClick = (e: SyntheticEvent, event: Event) => {
+        e.preventDefault();
+
+        window.open(event.eventMapLink, 'IIOEventMap');
+    };
+
+    return (
+        <ExpansionPanel defaultExpanded={!!containsSelectedEvent}>
+            <ExpansionPanelSummary>
+                {props.category}
+            </ExpansionPanelSummary>
+            <ExpansionPanelDetails>
+                <List className={classes.list}>
+                    {props.eventList.map((event: Event) => (
+                        <ListItem
+                            key={event.eventName}
+                            button={true}
+                            className={event.eventName === props.selectedEvent ? classes.selectedEvent : ''}
+                            onClick={() => props.onChangeSelectedEvent(event.eventName)}
+                        >
+                            <ListItemText
+                                primary={event.eventName}
+                                className={(event.eventMapLink? classes.eventTextWithMapLink : classes.eventText)} />
+                            {event.eventMapLink && <ListItemSecondaryAction>
+                                    <IconButton onClick={e => handleEventMapClick(e, event)} title="show on event map">
+                                        <MapIcon />
+                                    </IconButton>
+                            </ListItemSecondaryAction>}
+                        </ListItem>
+                    ))}
+                </List>
+            </ExpansionPanelDetails>
+        </ExpansionPanel>
+    );
+};
+
+export default EventCategoryExpansionPanel;

--- a/src/pages/events/EventForm.tsx
+++ b/src/pages/events/EventForm.tsx
@@ -49,7 +49,7 @@ const EventForm = (props: EventPayloadFormProps) => {
         const defaultEditorValue: Record<string, any> = convertJsonSchemaToEditorValue(props.event.schema, jsonSchemaDefinitions || {});
 
         const jsonCode = JSON.stringify(defaultEditorValue, null, 2);
-        const modelUri = monacoInstance.Uri.parse(`command_${props.event.eventName}.json`);
+        const modelUri = monacoInstance.Uri.parse(`event_${props.event.eventName}.json`);
         let model = monacoInstance.editor.getModel(modelUri);
 
         if (null === model) {

--- a/src/pages/events/EventForm.tsx
+++ b/src/pages/events/EventForm.tsx
@@ -1,0 +1,129 @@
+import {Button, Card, CardContent, Container, Divider, Typography} from '@material-ui/core';
+import Editor, {monaco} from '@monaco-editor/react';
+import React, {useEffect, useRef} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {Event, JSONSchema} from '../../api/types';
+import {makeThemeSelector} from '../../selector/settingsSelector';
+import {makeJsonSchemaDefinitionsSelector} from '../../selector/systemSchemaSelector';
+import AxiosResponseViewer from '../common/components/AxiosResponseViewer';
+import {Alert, AlertTitle} from '@material-ui/lab';
+import {convertJsonSchemaToEditorValue} from '../../util/convertJsonSchemaToEditorValue';
+import {makeEventErrorSelector, makeEventResponseSelector} from '../../selector/eventSelector';
+import {clearEvent, executeEvent} from '../../action/eventCommands';
+
+interface EventPayloadFormProps {
+    event: Event;
+}
+
+let monacoInstance: any = null;
+monaco.init().then(instance => monacoInstance = instance);
+
+const EventForm = (props: EventPayloadFormProps) => {
+
+    const dispatch = useDispatch();
+    const theme = useSelector(makeThemeSelector());
+    const jsonSchemaDefinitions: Record<string, JSONSchema> | null = useSelector(makeJsonSchemaDefinitionsSelector());
+    const response = useSelector(makeEventResponseSelector());
+    const error = useSelector(makeEventErrorSelector());
+    const valueGetterRef = useRef();
+    const editorRef = useRef();
+
+    useEffect(() => {
+        if (!editorRef.current) {
+            return;
+        }
+
+        dispatch(clearEvent({}));
+        updateEditorModel();
+        /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    }, [props.event]);
+
+    const handleEditorDidMount = (valueGetter: any, editor: any) => {
+        valueGetterRef.current = valueGetter;
+        editorRef.current = editor;
+
+        updateEditorModel();
+    };
+
+    const updateEditorModel = () => {
+        const defaultEditorValue: Record<string, any> = convertJsonSchemaToEditorValue(props.event.schema, jsonSchemaDefinitions || {});
+
+        const jsonCode = JSON.stringify(defaultEditorValue, null, 2);
+        const modelUri = monacoInstance.Uri.parse(`command_${props.event.eventName}.json`);
+        let model = monacoInstance.editor.getModel(modelUri);
+
+        if (null === model) {
+            model = monacoInstance.editor.createModel(jsonCode, 'json', modelUri);
+        } else  {
+            model.setValue(jsonCode);
+        }
+
+        monacoInstance.languages.json.jsonDefaults.setDiagnosticsOptions({
+            validate: true,
+            schemas: [{
+                fileMatch: [modelUri.toString()],
+                schema: { ...props.event.schema, definitions: jsonSchemaDefinitions },
+            }],
+        });
+
+        (editorRef.current as any).setModel(model);
+    };
+
+    const handleExecuteEvent = () => {
+        if (!valueGetterRef.current) {
+            return;
+        }
+
+        dispatch(executeEvent({
+            eventName: props.event.eventName,
+            payload: (valueGetterRef as any).current(),
+        }));
+    };
+
+    return (
+        <Card>
+            <CardContent>
+                <div style={{ height: '50px' }}>
+                    <Typography style={{ display: 'inline' }}>{props.event.eventName}</Typography>
+                    <Button
+                        style={{ float: 'right' }}
+                        variant={'contained'}
+                        color={'primary'}
+                        children={'Send'}
+                        onClick={handleExecuteEvent}
+                    />
+                </div>
+                <Editor
+                    height={'250px'}
+                    language={'json'}
+                    theme={theme === 'dark' ? 'dark' : undefined}
+                    editorDidMount={handleEditorDidMount}
+                    options={{
+                        minimap: {
+                            enabled: false,
+                        },
+                        formatOnPaste: true,
+                        scrollBeyondLastLine: false,
+                        hover: {
+                            delay: 500,
+                        },
+                    }}
+                />
+                <Divider style={{ marginTop: '10px', marginBottom: '10px' }} />
+                <div>
+                    {response && <AxiosResponseViewer response={response} />}
+                    {!response && error && (
+                        <Container disableGutters={true}>
+                            <Alert severity={'error'}>
+                                <AlertTitle>{error.name}</AlertTitle>
+                                {error.message}
+                            </Alert>
+                        </Container>
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    );
+};
+
+export default EventForm;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,11 +4,14 @@ export const queriesPath = '/queries';
 export const executeQueryPath = '/queries/:query';
 export const commandsPath = '/commands';
 export const executeCommandPath = '/commands/:command';
+export const eventsPath = '/events';
+export const executeEventPath = '/events/:event';
 export const aggregatePath = '/aggregates/:aggregateType';
 export const aggregateDetailsPath = '/aggregates/:aggregateType/:aggregateId/:version?';
 
 export const makeExecuteQueryPath = (query: string) => executeQueryPath.replace(':query', query);
 export const makeExecuteCommandPath = (command: string) => executeCommandPath.replace(':command', command);
+export const makeExecuteEventPath = (event: string) => executeEventPath.replace(':event', event);
 export const makeAggregateUrl = (aggregateType: string) => aggregatePath.replace(':aggregateType', aggregateType);
 export const makeAggregateDetailsUrl = (aggregateType: string, aggregateId: string, version?: number) =>
     aggregateDetailsPath

--- a/src/saga/fetchSystemSchemaFlow.ts
+++ b/src/saga/fetchSystemSchemaFlow.ts
@@ -40,7 +40,7 @@ export const onFetchSystemSchema = function*(retries?: number): any {
             }
 
             retries++;
-            yield delay(500 * retries);
+            yield delay(500);
             yield call(onFetchSystemSchema, retries);
         } else {
             yield call(onEnqueueErrorSnackbar, 'Loading the system schema failed');

--- a/src/selector/systemSchemaSelector.ts
+++ b/src/selector/systemSchemaSelector.ts
@@ -158,3 +158,9 @@ export const makeCommandListSelector = () => {
         return rawSchema ? rawSchema.commands : [];
     });
 };
+
+export const makeEventListSelector = () => {
+    return createSelector([systemSchemaSelector], rawSchema => {
+        return rawSchema ? rawSchema.events : [];
+    });
+};

--- a/src/selector/systemSchemaSelector.ts
+++ b/src/selector/systemSchemaSelector.ts
@@ -161,6 +161,6 @@ export const makeCommandListSelector = () => {
 
 export const makeEventListSelector = () => {
     return createSelector([systemSchemaSelector], rawSchema => {
-        return rawSchema ? rawSchema.events : [];
+        return rawSchema && rawSchema.events ? rawSchema.events : [];
     });
 };


### PR DESCRIPTION
With #20 being available I added an `EventsPage` that lists all events in categories (aggregate type or public events). It also supports deep linking like implemented in #21 

## Mobile Optimization
The PR also includes some minor mobile optimizations like `word-warp: break-word` for message names in panels and hiding side menu by default.

## Automatic Schema Reload
Whenever the cockpit window gets focus, it triggers a schema refresh now. If refresh fails, the responsible saga performs some retries and notifies the user about it.

Both optimizations are very useful in combination with a new functionality in InspectIO that allows you to open specific elements on the event map in Cockpit. 

![open_in_cockpit_2](https://user-images.githubusercontent.com/5131987/94287555-bfe5cc00-ff56-11ea-94d9-07626016db24.gif)
