### PR TITLE
Only replace system schema if it has been changed

### DIFF
--- a/src/saga/fetchSystemSchemaFlow.ts
+++ b/src/saga/fetchSystemSchemaFlow.ts
@@ -1,4 +1,4 @@
-import { call, delay, fork, put, take } from 'redux-saga/effects';
+import { call, delay, fork, put, select, take } from 'redux-saga/effects';
 import {fetchSystemSchema} from '../action/systemSchemaCommands';
 import {AggregateRelations, SystemSchema} from '../api/types';
 import {systemSchemaFetched} from '../action/systemSchemaEvents';
@@ -6,6 +6,7 @@ import {getSystemSchema} from '../api';
 import {onEnqueueErrorSnackbar, onEnqueueSuccessSnackbar, onEnqueueWarningSnackbar} from './enqueueSnackbarFlow';
 import {eeUiConfig, updateEeUiConfigEnv} from '../config';
 import * as _ from 'lodash';
+import {systemSchemaSelector} from '../selector/systemSchemaSelector';
 
 export const onFetchSystemSchema = function*(retries?: number): any {
     if(!retries) {
@@ -13,18 +14,23 @@ export const onFetchSystemSchema = function*(retries?: number): any {
     }
 
     try {
-        const systemSchema: SystemSchema = yield call(getSystemSchema);
-        yield put(systemSchemaFetched({ systemSchema }));
+        const currentSchema = yield select(systemSchemaSelector);
 
-        const config = eeUiConfig();
-        const aggregateConfig: {[aggregateType: string]: AggregateRelations} = _.clone(config.env.aggregateConfig);
-        for(const aggregate of systemSchema.aggregates) {
-            const userDefinedRelations = aggregateConfig[aggregate.aggregateType] || {};
-            if(aggregate.relations) {
-                aggregateConfig[aggregate.aggregateType] = {...aggregate.relations, ...userDefinedRelations};
+        const systemSchema: SystemSchema = yield call(getSystemSchema);
+
+        if(JSON.stringify(currentSchema) !== JSON.stringify(systemSchema)) {
+            yield put(systemSchemaFetched({ systemSchema }));
+
+            const config = eeUiConfig();
+            const aggregateConfig: {[aggregateType: string]: AggregateRelations} = _.clone(config.env.aggregateConfig);
+            for(const aggregate of systemSchema.aggregates) {
+                const userDefinedRelations = aggregateConfig[aggregate.aggregateType] || {};
+                if(aggregate.relations) {
+                    aggregateConfig[aggregate.aggregateType] = {...aggregate.relations, ...userDefinedRelations};
+                }
             }
+            updateEeUiConfigEnv({aggregateConfig});
         }
-        updateEeUiConfigEnv({aggregateConfig});
 
         if(retries > 0) {
             yield call(onEnqueueSuccessSnackbar, 'Connection is back. Successfully refreshed system schema', 3000);


### PR DESCRIPTION
In #22 I added a "Automatic Schema Reload" on window focus. It works great, but the forms get reset. Let's say you execute a query, switch to another tab and then back to the cockpit tab. The system schema is fetched again and replaced in the redux store. This causes the query form and result page to rerender, so your query result is gone.

To avoid the issue, I added a check if the system schema really changed and only than replace it. A more complicated solution (but probably better) would be to make a diff and only update the parts in the schema that have changed. I'll create a follow up for that.